### PR TITLE
Implementation Using Java TreeMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ lines). The downside to this approach is that it would be more complex, since it
 would prevent using some core Clojure functions which would have to be
 re-written to implement the same resulting functionality.
 
+*This Branch* represents an approach using a mutable TreeMap to aggregate
+frequencies across each line of a file (instead of reading in the entire file at
+once). The performance improvement is minimal from a timing perspective,
+dropping from 1.6 seconds to 1.5 seconds to process "Les Misérables".
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ well as the sorting functions, `alphabetical-order` and `frequency-order`.
 
 #### `word-count`
 
-Word count accepts a single string and returns a map of words to frequency
-values.
+Word count accepts a single string or a sequnce of strings and returns a map of
+words to frequency values.
 
 ```clojure
 (require '[concordance.core :as concordance])
@@ -138,7 +138,7 @@ values.
 
 The exposed
 [Comparator](http://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html)
-functions are designed to work with the core `sort-by` function.
+function is designed to work with the core `sort-by` function.
 
 ```clojure
 (sort-by concordance/frequency-order counts)
@@ -161,8 +161,8 @@ preference.
 
 This version is more efficient in memory, since it doesn't need to hold the
 whole file in memory to create the map. It can also store the word counts in a
-sorted collection, so does not incur the cost of sorting when the user has
-requested alphabetical ordering.
+sorted collection, so does not incur any additional cost of sorting when the
+user has requested alphabetical ordering.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -149,28 +149,20 @@ functions are designed to work with the core `sort-by` function.
 
 ## Performance
 
-Concordance is designed to run against a single string or file at a time. As
-such, it will load an entire text into memory in order to generate the
-concordance map. The text is normalized (converted to lowercase), and then
-broken into words. The resulting map will have an entry for each unique word.
-(So, for worst case, `(word-count (slurp "/usr/share/dict/words"))`.) Sorting
-this then performed against the resulting map.
-
-On my (slow) computer, this ends up being pretty reasonable. Generating and
-sorting the concordance for "Les Misérables" (one of the longest English books
-in the public domain) in about 1.6 seconds (plus JVM start-up overhead). A
-concordance for the `words` file (235,886 words on my laptop) takes about 4
-seconds.
-
-A more memory efficient approach would be to accept a stream of strings (or
-lines). The downside to this approach is that it would be more complex, since it
-would prevent using some core Clojure functions which would have to be
-re-written to implement the same resulting functionality.
-
-*This Branch* represents an approach using a mutable TreeMap to aggregate
+*This Branch* represents an approach using a mutable `TreeMap` to aggregate
 frequencies across each line of a file (instead of reading in the entire file at
-once). The performance improvement is minimal from a timing perspective,
+once). The time performance improvement is minimal,
 dropping from 1.6 seconds to 1.5 seconds to process "Les Misérables".
+
+From a maintenance perspective, this version is more complicated. Additionally,
+it doesn't naturally match the API of the first version, so `word-count` has to
+handle all the logic of both performing the word count and sorting to
+preference.
+
+This version is more efficient in memory, since it doesn't need to hold the
+whole file in memory to create the map. It can also store the word counts in a
+sorted collection, so does not incur the cost of sorting when the user has
+requested alphabetical ordering.
 
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject concordance "0.2.0-SNAPSHOT"
+(defproject concordance "0.2.0"
   :description "A library to tell how often words appear in a text."
   :url "https://github.com/defndaines/concordance"
   :license {:name "Eclipse Public License"

--- a/src/concordance/core.clj
+++ b/src/concordance/core.clj
@@ -76,5 +76,8 @@
       (exit (if ok? 0 1) exit-message)
       (with-open [reader (clojure.java.io/reader file-name)]
         (let [counts (reduce count-reducer! (TreeMap.) (line-seq reader))]
-          (doseq [[word freq] counts]
-            (println (str word " " freq))))))))
+          (if (= "freq" sort-order)
+            (doseq [[word freq] (sort-by frequency-order counts)]
+              (println (str word " " freq)))
+            (doseq [[word freq] counts]
+              (println (str word " " freq)))))))))

--- a/test/concordance/core_test.clj
+++ b/test/concordance/core_test.clj
@@ -25,9 +25,9 @@
   (let [phrase "I read the book \"One Fish, Two Fish, Red Fish, Blue Fish\"
                until I was blue in the face."
         dance (word-count phrase)]
-    (testing "Sort alphabetically."
+    (testing "Sorted alphabetically by default."
       (is (= `("blue" "book" "face")
-             (take 3 (map first (sort-by alphabetical-order dance))))))
+             (take 3 (map first dance)))))
     (testing "Sort by frequency"
       (is (= '(["fish" 4] ["blue" 2] ["i" 2] ["the" 2] ["book" 1])
              (take 5 (sort-by frequency-order dance)))))))


### PR DESCRIPTION
The native `frequencies` method works great for single strings, but requires that the entire text be brought into memory in order to calculate the word count. To handle streaming data, such as reading a large file line-by-line (largest novels are greater than 60,000 lines), it is easier to use a mutable reducer on a Java `TreeMap`. To provide a Clojure-native API, though, the `TreeMap` is converted to a `sorted-map`. To be more efficient, the `sorted-map` could be skipped and just print to STDOUT from the `TreeMap` entries.